### PR TITLE
Stage 4: AgentDx bridge — Langfuse poller, trace converter, Prometheus exporter

### DIFF
--- a/agentdx_bridge/Dockerfile
+++ b/agentdx_bridge/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install dependencies first for layer caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY . .
+
+# Non-root user for security
+RUN useradd -m bridge && chown -R bridge:bridge /app
+USER bridge
+
+# Prometheus metrics port
+EXPOSE 7700
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:7700/health')"
+
+CMD ["python", "-m", "agentdx_bridge.main"]

--- a/agentdx_bridge/__init__.py
+++ b/agentdx_bridge/__init__.py
@@ -1,0 +1,1 @@
+# agentdx-bridge: Langfuse poller → agentdx Diagnoser → Prometheus metrics

--- a/agentdx_bridge/langfuse_converter.py
+++ b/agentdx_bridge/langfuse_converter.py
@@ -1,0 +1,242 @@
+"""
+Langfuse TraceWithFullDetails → agentdx Trace/Message/ToolCall converter.
+
+Spike 3 findings (SCOPE.md):
+  - GENERATION observation input[] holds system/user messages (not separate observations)
+  - GENERATION output → assistant Message; extract ToolCall from tool_use blocks
+  - TOOL observation → tool Message (success = level != "ERROR")
+  - Sort all observations by startTime → step_index
+  - 80% of fields map directly; main work is message unpacking
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+
+# ── agentdx schema (imported at runtime; defined here as fallback dataclasses) ─
+
+try:
+    from agentdx.models import Message, ToolCall, Trace  # type: ignore[import]
+    _AGENTDX_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _AGENTDX_AVAILABLE = False
+
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class ToolCall:  # type: ignore[no-redef]
+        tool_name: str
+        tool_input: dict = field(default_factory=dict)
+        tool_output: str | None = None
+        success: bool = True
+        error_message: str | None = None
+        step_index: int = 0
+
+    @dataclass
+    class Message:  # type: ignore[no-redef]
+        role: str          # system | user | assistant | tool
+        content: str
+        step_index: int = 0
+        tool_calls: list[ToolCall] = field(default_factory=list)
+
+    @dataclass
+    class Trace:  # type: ignore[no-redef]
+        trace_id: str
+        session_id: str
+        messages: list[Message] = field(default_factory=list)
+        metadata: dict = field(default_factory=dict)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _parse_time(ts: str | None) -> datetime:
+    """Parse ISO-8601 timestamp from Langfuse into datetime."""
+    if not ts:
+        return datetime.min
+    ts = ts.rstrip("Z")
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return datetime.strptime(ts, fmt)
+        except ValueError:
+            continue
+    return datetime.min
+
+
+def _content_to_str(content: Any) -> str:
+    """Normalise Langfuse content to a plain string."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                btype = block.get("type", "")
+                if btype == "text":
+                    parts.append(block.get("text", ""))
+                elif btype == "tool_use":
+                    parts.append(f"[tool_use:{block.get('name','')}]")
+                elif btype == "tool_result":
+                    inner = block.get("content", "")
+                    parts.append(_content_to_str(inner))
+                else:
+                    parts.append(str(block))
+            else:
+                parts.append(str(block))
+        return "\n".join(p for p in parts if p)
+    if isinstance(content, dict):
+        return json.dumps(content)
+    return str(content)
+
+
+def _extract_tool_calls(content: Any, step_index: int) -> list[ToolCall]:
+    """Extract ToolCall objects from an assistant message's content blocks."""
+    if not isinstance(content, list):
+        return []
+    calls = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_use":
+            continue
+        calls.append(ToolCall(
+            tool_name=block.get("name", "unknown"),
+            tool_input=block.get("input", {}),
+            tool_output=None,   # filled in when matching TOOL observation
+            success=True,
+            error_message=None,
+            step_index=step_index,
+        ))
+    return calls
+
+
+# ── main converter ────────────────────────────────────────────────────────────
+
+def convert(langfuse_trace: dict) -> Trace | None:
+    """
+    Convert a Langfuse TraceWithFullDetails dict to an agentdx Trace.
+
+    Returns None if the trace has no observations worth analysing.
+    """
+    trace_id: str = langfuse_trace.get("id", "unknown")
+    session_id: str = langfuse_trace.get("sessionId") or trace_id
+
+    observations: list[dict] = langfuse_trace.get("observations", [])
+    if not observations:
+        log.debug("trace %s has no observations — skipping", trace_id)
+        return None
+
+    # Sort observations by startTime so step_index is chronological
+    observations = sorted(observations, key=lambda o: _parse_time(o.get("startTime")))
+
+    messages: list[Message] = []
+
+    for step_index, obs in enumerate(observations):
+        obs_type: str = (obs.get("type") or "").upper()
+        level: str = obs.get("level", "DEFAULT")
+        status_msg: str = obs.get("statusMessage") or ""
+
+        if obs_type == "GENERATION":
+            # ── unpack system/user messages from input array ──────────────────
+            raw_input = obs.get("input")
+            if isinstance(raw_input, list):
+                for msg_block in raw_input:
+                    if not isinstance(msg_block, dict):
+                        continue
+                    role = msg_block.get("role", "user")
+                    content_str = _content_to_str(msg_block.get("content", ""))
+                    if content_str:
+                        messages.append(Message(
+                            role=role,
+                            content=content_str,
+                            step_index=step_index,
+                            tool_calls=[],
+                        ))
+            elif isinstance(raw_input, dict):
+                role = raw_input.get("role", "user")
+                content_str = _content_to_str(raw_input.get("content", ""))
+                if content_str:
+                    messages.append(Message(
+                        role=role,
+                        content=content_str,
+                        step_index=step_index,
+                        tool_calls=[],
+                    ))
+
+            # ── GENERATION output → assistant message + tool calls ────────────
+            raw_output = obs.get("output")
+            if raw_output is not None:
+                output_content = raw_output
+                # Langfuse may wrap in {"role": "assistant", "content": [...]}
+                if isinstance(raw_output, dict) and "content" in raw_output:
+                    output_content = raw_output["content"]
+
+                tool_calls = _extract_tool_calls(output_content, step_index)
+                content_str = _content_to_str(output_content)
+
+                if content_str or tool_calls:
+                    messages.append(Message(
+                        role="assistant",
+                        content=content_str,
+                        step_index=step_index,
+                        tool_calls=tool_calls,
+                    ))
+
+        elif obs_type == "TOOL":
+            # ── TOOL observation → tool result message ────────────────────────
+            success = level != "ERROR"
+            raw_output = obs.get("output")
+            output_str = _content_to_str(raw_output)
+
+            tool_call = ToolCall(
+                tool_name=obs.get("name", "unknown"),
+                tool_input=obs.get("input") or {},
+                tool_output=output_str,
+                success=success,
+                error_message=status_msg if not success else None,
+                step_index=step_index,
+            )
+            messages.append(Message(
+                role="tool",
+                content=output_str,
+                step_index=step_index,
+                tool_calls=[tool_call],
+            ))
+
+        else:
+            # SPAN, EVENT, or unknown — treat as a system annotation if it has output
+            raw_output = obs.get("output")
+            if raw_output is not None:
+                content_str = _content_to_str(raw_output)
+                if content_str:
+                    messages.append(Message(
+                        role="system",
+                        content=f"[{obs.get('name', obs_type)}] {content_str}",
+                        step_index=step_index,
+                        tool_calls=[],
+                    ))
+
+    if not messages:
+        log.debug("trace %s produced no messages after conversion — skipping", trace_id)
+        return None
+
+    metadata = {
+        "name": langfuse_trace.get("name", ""),
+        "tags": langfuse_trace.get("tags", []),
+        "userId": langfuse_trace.get("userId"),
+        "observation_count": len(observations),
+    }
+
+    return Trace(
+        trace_id=trace_id,
+        session_id=session_id,
+        messages=messages,
+        metadata=metadata,
+    )

--- a/agentdx_bridge/main.py
+++ b/agentdx_bridge/main.py
@@ -1,0 +1,284 @@
+"""
+agentdx-bridge: Langfuse poller → agentdx Diagnoser → Prometheus metrics.
+
+Architecture:
+  1. Poll Langfuse for completed traces (cursor-based, persisted across restarts)
+  2. Convert each trace via langfuse_converter.convert()
+  3. Run agentdx.Diagnoser.diagnose() → DiagnosticReport
+  4. Expose pathology counts + health scores as Prometheus metrics
+  5. Serve metrics on :METRICS_PORT/metrics
+
+Environment variables:
+  LANGFUSE_HOST              Langfuse server URL (default: http://langfuse:3000)
+  LANGFUSE_PUBLIC_KEY        Langfuse project public key
+  LANGFUSE_SECRET_KEY        Langfuse project secret key
+  AGENTDX_POLL_INTERVAL      Seconds between polls (default: 30)
+  METRICS_PORT               Port for Prometheus metrics endpoint (default: 7700)
+  CURSOR_FILE                Path to persist poll cursor (default: /tmp/agentdx_cursor.txt)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from threading import Thread
+
+log = logging.getLogger(__name__)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+)
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+LANGFUSE_HOST = os.environ.get("LANGFUSE_HOST", "http://langfuse:3000")
+LANGFUSE_PUBLIC_KEY = os.environ.get("LANGFUSE_PUBLIC_KEY", "")
+LANGFUSE_SECRET_KEY = os.environ.get("LANGFUSE_SECRET_KEY", "")
+POLL_INTERVAL = int(os.environ.get("AGENTDX_POLL_INTERVAL", "30"))
+METRICS_PORT = int(os.environ.get("METRICS_PORT", "7700"))
+CURSOR_FILE = Path(os.environ.get("CURSOR_FILE", "/tmp/agentdx_cursor.txt"))
+
+# ── Prometheus metrics ────────────────────────────────────────────────────────
+
+try:
+    from prometheus_client import (
+        Counter, Gauge, start_http_server, generate_latest, CONTENT_TYPE_LATEST,
+    )
+    _PROM_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _PROM_AVAILABLE = False
+    log.warning("prometheus_client not installed — metrics endpoint will be unavailable")
+
+if _PROM_AVAILABLE:
+    PATHOLOGY_COUNTER = Counter(
+        "agentdx_pathology_detections_total",
+        "Total pathology detections by type",
+        ["pathology"],
+    )
+    HEALTH_SCORE = Gauge(
+        "agentdx_health_score",
+        "Agent health score per session (0–1)",
+        ["session_id"],
+    )
+    TRACES_PROCESSED = Counter(
+        "agentdx_traces_processed_total",
+        "Total traces processed by the bridge",
+    )
+    TRACES_ERRORED = Counter(
+        "agentdx_traces_errored_total",
+        "Total traces that failed processing",
+    )
+    POLL_DURATION = Gauge(
+        "agentdx_poll_duration_seconds",
+        "Duration of the last Langfuse poll cycle",
+    )
+
+# ── Cursor persistence ────────────────────────────────────────────────────────
+
+def _load_cursor() -> str:
+    """Load the last-processed timestamp from disk."""
+    if CURSOR_FILE.exists():
+        val = CURSOR_FILE.read_text().strip()
+        if val:
+            return val
+    # Default: start from 24h ago to catch recent traces
+    since = datetime.now(tz=timezone.utc).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    ).isoformat()
+    return since
+
+
+def _save_cursor(ts: str) -> None:
+    CURSOR_FILE.write_text(ts)
+
+
+# ── Langfuse polling ──────────────────────────────────────────────────────────
+
+def _poll_langfuse(from_ts: str) -> tuple[list[dict], str]:
+    """
+    Fetch traces from Langfuse created after from_ts.
+    Returns (traces, next_cursor_ts).
+    Uses Langfuse Python SDK if available, falls back to raw HTTP.
+    """
+    try:
+        from langfuse import Langfuse  # type: ignore[import]
+        client = Langfuse(
+            host=LANGFUSE_HOST,
+            public_key=LANGFUSE_PUBLIC_KEY,
+            secret_key=LANGFUSE_SECRET_KEY,
+        )
+        result = client.get_traces(
+            from_timestamp=from_ts,
+            order_by="timestamp.asc",
+            limit=50,
+        )
+        traces_raw = [t.dict() if hasattr(t, "dict") else vars(t) for t in result.data]
+        # Advance cursor to the latest timestamp seen
+        next_ts = from_ts
+        if traces_raw:
+            last_ts = traces_raw[-1].get("timestamp") or traces_raw[-1].get("createdAt") or from_ts
+            if isinstance(last_ts, datetime):
+                next_ts = last_ts.isoformat()
+            elif isinstance(last_ts, str):
+                next_ts = last_ts
+        return traces_raw, next_ts
+
+    except ImportError:
+        log.error("langfuse SDK not installed — cannot poll traces")
+        return [], from_ts
+    except Exception as exc:
+        log.warning("Langfuse poll failed: %s", exc)
+        return [], from_ts
+
+
+def _fetch_full_trace(trace_id: str) -> dict | None:
+    """Fetch a single trace with full observation details."""
+    try:
+        from langfuse import Langfuse  # type: ignore[import]
+        client = Langfuse(
+            host=LANGFUSE_HOST,
+            public_key=LANGFUSE_PUBLIC_KEY,
+            secret_key=LANGFUSE_SECRET_KEY,
+        )
+        trace = client.get_trace(trace_id)
+        return trace.dict() if hasattr(trace, "dict") else vars(trace)
+    except Exception as exc:
+        log.warning("Failed to fetch full trace %s: %s", trace_id, exc)
+        return None
+
+
+# ── agentdx diagnosis ─────────────────────────────────────────────────────────
+
+def _diagnose(trace_dict: dict) -> None:
+    """Convert trace, run Diagnoser, update Prometheus metrics."""
+    from agentdx_bridge.langfuse_converter import convert  # type: ignore[import]
+
+    agentdx_trace = convert(trace_dict)
+    if agentdx_trace is None:
+        return
+
+    try:
+        from agentdx import Diagnoser  # type: ignore[import]
+        report = Diagnoser().diagnose(agentdx_trace)
+    except ImportError:
+        log.error("agentdx not installed — cannot run diagnosis")
+        return
+    except Exception as exc:
+        log.warning("Diagnoser failed for trace %s: %s", agentdx_trace.trace_id, exc)
+        if _PROM_AVAILABLE:
+            TRACES_ERRORED.inc()
+        return
+
+    if _PROM_AVAILABLE:
+        TRACES_PROCESSED.inc()
+
+        # Health score
+        score = getattr(report, "health_score", None)
+        if score is not None:
+            HEALTH_SCORE.labels(session_id=agentdx_trace.session_id).set(score)
+
+        # Pathology detections
+        detections = getattr(report, "detections", []) or []
+        for detection in detections:
+            pathology = getattr(detection, "pathology", None) or str(detection)
+            PATHOLOGY_COUNTER.labels(pathology=str(pathology)).inc()
+
+    log.info(
+        "trace %s — health=%.2f detections=%d",
+        agentdx_trace.trace_id,
+        getattr(report, "health_score", 0.0) or 0.0,
+        len(getattr(report, "detections", []) or []),
+    )
+
+
+# ── Poll loop ─────────────────────────────────────────────────────────────────
+
+def run_poll_loop() -> None:
+    cursor = _load_cursor()
+    log.info("Starting poll loop — Langfuse=%s interval=%ds from=%s",
+             LANGFUSE_HOST, POLL_INTERVAL, cursor)
+
+    while True:
+        t0 = time.monotonic()
+        try:
+            traces, next_cursor = _poll_langfuse(cursor)
+            for trace_stub in traces:
+                trace_id = trace_stub.get("id")
+                if not trace_id:
+                    continue
+                full_trace = _fetch_full_trace(trace_id)
+                if full_trace:
+                    _diagnose(full_trace)
+
+            if next_cursor != cursor:
+                cursor = next_cursor
+                _save_cursor(cursor)
+                log.debug("cursor advanced to %s", cursor)
+
+        except Exception as exc:
+            log.error("Poll cycle error: %s", exc)
+
+        elapsed = time.monotonic() - t0
+        if _PROM_AVAILABLE:
+            POLL_DURATION.set(elapsed)
+
+        sleep_for = max(0, POLL_INTERVAL - elapsed)
+        time.sleep(sleep_for)
+
+
+# ── Metrics HTTP server (fallback if prometheus_client not available) ─────────
+
+class _MetricsHandler(BaseHTTPRequestHandler):
+    def log_message(self, *_): pass
+
+    def do_GET(self):
+        if self.path == "/metrics":
+            if _PROM_AVAILABLE:
+                data = generate_latest()
+                self.send_response(200)
+                self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+            else:
+                body = b"# prometheus_client not available\n"
+                self.send_response(503)
+                self.send_header("Content-Type", "text/plain")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+        elif self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def start_metrics_server() -> None:
+    if _PROM_AVAILABLE:
+        # prometheus_client's built-in HTTP server
+        start_http_server(METRICS_PORT)
+        log.info("Prometheus metrics on :%d/metrics", METRICS_PORT)
+    else:
+        server = HTTPServer(("0.0.0.0", METRICS_PORT), _MetricsHandler)
+        t = Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        log.info("Fallback metrics server on :%d/metrics", METRICS_PORT)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> None:
+    start_metrics_server()
+    run_poll_loop()
+
+
+if __name__ == "__main__":
+    main()

--- a/agentdx_bridge/requirements.txt
+++ b/agentdx_bridge/requirements.txt
@@ -1,0 +1,3 @@
+agentdx>=0.1.0
+langfuse>=2.0.0,<3.0.0
+prometheus_client>=0.19.0

--- a/tests/test_stage4_agentdx_bridge.py
+++ b/tests/test_stage4_agentdx_bridge.py
@@ -1,0 +1,500 @@
+"""
+Stage 4 validation tests: AgentDx bridge — converter, Dockerfile, structure.
+
+The converter is tested with fixture data (no agentdx/langfuse runtime needed).
+Dockerfile and requirements are validated structurally.
+
+Run:
+  pytest tests/test_stage4_agentdx_bridge.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BRIDGE_DIR = REPO_ROOT / "agentdx_bridge"
+
+# Inject bridge dir so we can import the converter directly
+sys.path.insert(0, str(REPO_ROOT))
+
+
+# ── Fixtures: Langfuse trace shapes ──────────────────────────────────────────
+
+GENERATION_WITH_TOOL_USE = {
+    "id": "trace-001",
+    "sessionId": "session-abc",
+    "name": "claude-code-session",
+    "tags": [],
+    "observations": [
+        {
+            "id": "obs-gen-1",
+            "type": "GENERATION",
+            "name": "llm-call",
+            "startTime": "2026-03-31T10:00:00.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Read the file /tmp/test.txt"},
+            ],
+            "output": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I'll read that file for you."},
+                    {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "read_file",
+                        "input": {"path": "/tmp/test.txt"},
+                    },
+                ],
+            },
+        },
+        {
+            "id": "obs-tool-1",
+            "type": "TOOL",
+            "name": "read_file",
+            "startTime": "2026-03-31T10:00:01.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": {"path": "/tmp/test.txt"},
+            "output": "hello world",
+        },
+        {
+            "id": "obs-gen-2",
+            "type": "GENERATION",
+            "name": "llm-call-2",
+            "startTime": "2026-03-31T10:00:02.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [
+                {"role": "user", "content": "Read the file /tmp/test.txt"},
+                {"role": "assistant", "content": "I'll read that file."},
+                {"role": "tool", "content": "hello world"},
+            ],
+            "output": {"role": "assistant", "content": [
+                {"type": "text", "text": "The file contains: hello world"}
+            ]},
+        },
+    ],
+}
+
+GENERATION_WITH_ERROR_TOOL = {
+    "id": "trace-002",
+    "sessionId": "session-err",
+    "name": "failing-session",
+    "tags": [],
+    "observations": [
+        {
+            "id": "obs-gen",
+            "type": "GENERATION",
+            "name": "llm",
+            "startTime": "2026-03-31T10:00:00.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [{"role": "user", "content": "Delete /etc/passwd"}],
+            "output": {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "bash", "input": {"cmd": "rm /etc/passwd"}}
+            ]},
+        },
+        {
+            "id": "obs-tool-err",
+            "type": "TOOL",
+            "name": "bash",
+            "startTime": "2026-03-31T10:00:01.000",
+            "level": "ERROR",
+            "statusMessage": "Permission denied",
+            "input": {"cmd": "rm /etc/passwd"},
+            "output": None,
+        },
+    ],
+}
+
+SIMPLE_TEXT_ONLY = {
+    "id": "trace-003",
+    "sessionId": "session-simple",
+    "name": "simple",
+    "tags": [],
+    "observations": [
+        {
+            "id": "obs-1",
+            "type": "GENERATION",
+            "name": "llm",
+            "startTime": "2026-03-31T10:00:00.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [{"role": "user", "content": "Say hello"}],
+            "output": {"role": "assistant", "content": [{"type": "text", "text": "Hello!"}]},
+        }
+    ],
+}
+
+EMPTY_OBSERVATIONS = {
+    "id": "trace-empty",
+    "sessionId": "session-empty",
+    "observations": [],
+}
+
+STRING_CONTENT = {
+    "id": "trace-str",
+    "sessionId": "session-str",
+    "observations": [
+        {
+            "id": "obs-1",
+            "type": "GENERATION",
+            "name": "llm",
+            "startTime": "2026-03-31T10:00:00.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [{"role": "user", "content": "ping"}],
+            "output": "pong",  # string output (not dict)
+        }
+    ],
+}
+
+OUT_OF_ORDER_TIMESTAMPS = {
+    "id": "trace-order",
+    "sessionId": "session-order",
+    "observations": [
+        {
+            "id": "obs-b",
+            "type": "GENERATION",
+            "name": "second",
+            "startTime": "2026-03-31T10:00:02.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [{"role": "user", "content": "second"}],
+            "output": {"role": "assistant", "content": [{"type": "text", "text": "B"}]},
+        },
+        {
+            "id": "obs-a",
+            "type": "GENERATION",
+            "name": "first",
+            "startTime": "2026-03-31T10:00:01.000",
+            "level": "DEFAULT",
+            "statusMessage": None,
+            "input": [{"role": "user", "content": "first"}],
+            "output": {"role": "assistant", "content": [{"type": "text", "text": "A"}]},
+        },
+    ],
+}
+
+
+# ── File structure ────────────────────────────────────────────────────────────
+
+def test_bridge_init_exists():
+    assert (BRIDGE_DIR / "__init__.py").exists()
+
+def test_bridge_main_exists():
+    assert (BRIDGE_DIR / "main.py").exists()
+
+def test_bridge_converter_exists():
+    assert (BRIDGE_DIR / "langfuse_converter.py").exists()
+
+def test_bridge_dockerfile_exists():
+    assert (BRIDGE_DIR / "Dockerfile").exists()
+
+def test_bridge_requirements_exists():
+    assert (BRIDGE_DIR / "requirements.txt").exists()
+
+
+# ── requirements.txt ─────────────────────────────────────────────────────────
+
+def test_requirements_has_agentdx():
+    content = (BRIDGE_DIR / "requirements.txt").read_text()
+    assert "agentdx" in content
+
+def test_requirements_has_langfuse():
+    content = (BRIDGE_DIR / "requirements.txt").read_text()
+    assert "langfuse" in content
+
+def test_requirements_has_prometheus_client():
+    content = (BRIDGE_DIR / "requirements.txt").read_text()
+    assert "prometheus_client" in content
+
+def test_requirements_pins_langfuse_v2():
+    """Must use langfuse v2 SDK (<3.0) matching the Langfuse v2 server."""
+    content = (BRIDGE_DIR / "requirements.txt").read_text()
+    assert "<3" in content or "2." in content, (
+        "langfuse dependency must be pinned to v2 (<3.0) to match the server"
+    )
+
+
+# ── Dockerfile ────────────────────────────────────────────────────────────────
+
+def test_dockerfile_uses_python_311():
+    content = (BRIDGE_DIR / "Dockerfile").read_text()
+    assert "python:3.11" in content or "python:3.12" in content, (
+        "Dockerfile must use Python 3.11+"
+    )
+
+def test_dockerfile_installs_requirements():
+    content = (BRIDGE_DIR / "Dockerfile").read_text()
+    assert "requirements.txt" in content
+
+def test_dockerfile_exposes_7700():
+    content = (BRIDGE_DIR / "Dockerfile").read_text()
+    assert "EXPOSE 7700" in content
+
+def test_dockerfile_has_healthcheck():
+    content = (BRIDGE_DIR / "Dockerfile").read_text()
+    assert "HEALTHCHECK" in content
+
+def test_dockerfile_has_non_root_user():
+    content = (BRIDGE_DIR / "Dockerfile").read_text()
+    assert "USER" in content, "Dockerfile should run as non-root user"
+
+def test_dockerfile_cmd_runs_main():
+    content = (BRIDGE_DIR / "Dockerfile").read_text()
+    assert "main" in content
+
+
+# ── main.py structure ─────────────────────────────────────────────────────────
+
+def test_main_has_env_vars_documented():
+    content = (BRIDGE_DIR / "main.py").read_text()
+    for var in ("LANGFUSE_HOST", "LANGFUSE_PUBLIC_KEY", "LANGFUSE_SECRET_KEY",
+                "AGENTDX_POLL_INTERVAL", "METRICS_PORT"):
+        assert var in content, f"main.py must reference env var: {var}"
+
+def test_main_has_prometheus_metrics():
+    content = (BRIDGE_DIR / "main.py").read_text()
+    assert "agentdx_pathology_detections_total" in content
+    assert "agentdx_health_score" in content
+
+def test_main_has_cursor_persistence():
+    content = (BRIDGE_DIR / "main.py").read_text()
+    assert "cursor" in content.lower()
+
+def test_main_has_poll_loop():
+    content = (BRIDGE_DIR / "main.py").read_text()
+    assert "poll" in content.lower()
+
+def test_main_has_metrics_server():
+    content = (BRIDGE_DIR / "main.py").read_text()
+    assert "metrics" in content.lower() and ("7700" in content or "METRICS_PORT" in content)
+
+
+# ── Converter: import ─────────────────────────────────────────────────────────
+
+def test_converter_imports():
+    from agentdx_bridge.langfuse_converter import convert  # noqa: F401
+
+
+# ── Converter: empty observations → None ─────────────────────────────────────
+
+def test_convert_empty_observations_returns_none():
+    from agentdx_bridge.langfuse_converter import convert
+    result = convert(EMPTY_OBSERVATIONS)
+    assert result is None
+
+
+# ── Converter: basic GENERATION → messages ───────────────────────────────────
+
+def test_convert_simple_returns_trace():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    assert trace is not None
+
+def test_convert_simple_trace_id():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    assert trace.trace_id == "trace-003"
+
+def test_convert_simple_session_id():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    assert trace.session_id == "session-simple"
+
+def test_convert_simple_has_user_message():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    roles = [m.role for m in trace.messages]
+    assert "user" in roles
+
+def test_convert_simple_has_assistant_message():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    roles = [m.role for m in trace.messages]
+    assert "assistant" in roles
+
+def test_convert_simple_user_content():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    user_msgs = [m for m in trace.messages if m.role == "user"]
+    assert any("Say hello" in m.content for m in user_msgs)
+
+def test_convert_simple_assistant_content():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(SIMPLE_TEXT_ONLY)
+    assistant_msgs = [m for m in trace.messages if m.role == "assistant"]
+    assert any("Hello" in m.content for m in assistant_msgs)
+
+
+# ── Converter: GENERATION with tool_use → ToolCall ───────────────────────────
+
+def test_convert_tool_use_trace_not_none():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    assert trace is not None
+
+def test_convert_tool_use_has_system_message():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    roles = [m.role for m in trace.messages]
+    assert "system" in roles
+
+def test_convert_tool_use_assistant_has_tool_calls():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    assistant_msgs = [m for m in trace.messages if m.role == "assistant"]
+    all_tool_calls = [tc for m in assistant_msgs for tc in m.tool_calls]
+    assert len(all_tool_calls) > 0, "Expected ToolCall objects from tool_use blocks"
+
+def test_convert_tool_call_name():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    assistant_msgs = [m for m in trace.messages if m.role == "assistant"]
+    tool_names = [tc.tool_name for m in assistant_msgs for tc in m.tool_calls]
+    assert "read_file" in tool_names
+
+def test_convert_tool_call_input():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    assistant_msgs = [m for m in trace.messages if m.role == "assistant"]
+    for m in assistant_msgs:
+        for tc in m.tool_calls:
+            if tc.tool_name == "read_file":
+                assert tc.tool_input.get("path") == "/tmp/test.txt"
+                return
+    pytest.fail("read_file ToolCall not found")
+
+def test_convert_tool_observation_produces_tool_message():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    roles = [m.role for m in trace.messages]
+    assert "tool" in roles
+
+def test_convert_tool_message_success_true():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    tool_msgs = [m for m in trace.messages if m.role == "tool"]
+    assert all(tc.success for m in tool_msgs for tc in m.tool_calls)
+
+def test_convert_tool_message_output():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    tool_msgs = [m for m in trace.messages if m.role == "tool"]
+    assert any("hello world" in m.content for m in tool_msgs)
+
+
+# ── Converter: error TOOL observation ────────────────────────────────────────
+
+def test_convert_error_tool_success_false():
+    """TOOL observation with level=ERROR must produce success=False."""
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_ERROR_TOOL)
+    assert trace is not None
+    tool_msgs = [m for m in trace.messages if m.role == "tool"]
+    error_calls = [tc for m in tool_msgs for tc in m.tool_calls if not tc.success]
+    assert len(error_calls) > 0, "Expected at least one failed ToolCall"
+
+def test_convert_error_tool_error_message():
+    """statusMessage must be mapped to error_message on failed ToolCall."""
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_ERROR_TOOL)
+    tool_msgs = [m for m in trace.messages if m.role == "tool"]
+    for m in tool_msgs:
+        for tc in m.tool_calls:
+            if not tc.success:
+                assert tc.error_message == "Permission denied"
+                return
+    pytest.fail("No failed ToolCall with error_message found")
+
+
+# ── Converter: step_index ordering ───────────────────────────────────────────
+
+def test_convert_step_index_chronological():
+    """Messages must be ordered by startTime regardless of observation order in input."""
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(OUT_OF_ORDER_TIMESTAMPS)
+    assert trace is not None
+    step_indices = [m.step_index for m in trace.messages]
+    # step_indices should be non-decreasing (observations sorted by startTime)
+    assert step_indices == sorted(step_indices), (
+        f"Messages not in chronological order: {step_indices}"
+    )
+
+def test_convert_earlier_observation_lower_step_index():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(OUT_OF_ORDER_TIMESTAMPS)
+    # obs-a (10:00:01) should come before obs-b (10:00:02)
+    first_content = trace.messages[0].content if trace.messages else ""
+    # The "first" observation (obs-a, startTime 10:00:01) should produce content "A"
+    user_msgs = [m for m in trace.messages if m.role == "user"]
+    assert user_msgs[0].content == "first", (
+        f"First user message should be 'first' (earliest timestamp), got: {user_msgs[0].content!r}"
+    )
+
+
+# ── Converter: string output ──────────────────────────────────────────────────
+
+def test_convert_string_output():
+    """GENERATION output can be a plain string (not a dict)."""
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(STRING_CONTENT)
+    assert trace is not None
+    assistant_msgs = [m for m in trace.messages if m.role == "assistant"]
+    assert len(assistant_msgs) > 0
+
+def test_convert_string_output_content():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(STRING_CONTENT)
+    assistant_msgs = [m for m in trace.messages if m.role == "assistant"]
+    assert any("pong" in m.content for m in assistant_msgs)
+
+
+# ── Converter: metadata ───────────────────────────────────────────────────────
+
+def test_convert_metadata_has_observation_count():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    assert trace.metadata.get("observation_count") == 3
+
+def test_convert_metadata_has_name():
+    from agentdx_bridge.langfuse_converter import convert
+    trace = convert(GENERATION_WITH_TOOL_USE)
+    assert trace.metadata.get("name") == "claude-code-session"
+
+
+# ── Converter helper: _content_to_str ────────────────────────────────────────
+
+def test_content_to_str_none():
+    from agentdx_bridge.langfuse_converter import _content_to_str
+    assert _content_to_str(None) == ""
+
+def test_content_to_str_string():
+    from agentdx_bridge.langfuse_converter import _content_to_str
+    assert _content_to_str("hello") == "hello"
+
+def test_content_to_str_text_block():
+    from agentdx_bridge.langfuse_converter import _content_to_str
+    result = _content_to_str([{"type": "text", "text": "hello"}])
+    assert result == "hello"
+
+def test_content_to_str_tool_use_block():
+    from agentdx_bridge.langfuse_converter import _content_to_str
+    result = _content_to_str([{"type": "tool_use", "name": "bash"}])
+    assert "tool_use" in result and "bash" in result
+
+def test_content_to_str_mixed_blocks():
+    from agentdx_bridge.langfuse_converter import _content_to_str
+    result = _content_to_str([
+        {"type": "text", "text": "Let me run"},
+        {"type": "tool_use", "name": "bash", "input": {}},
+    ])
+    assert "Let me run" in result


### PR DESCRIPTION
Closes #7

## Summary

- `agentdx_bridge/langfuse_converter.py` — converts Langfuse traces to agentdx schema
- `agentdx_bridge/main.py` — cursor-persisted poll loop, Diagnoser, Prometheus metrics
- `agentdx_bridge/Dockerfile` — Python 3.11-slim, non-root, EXPOSE 7700, HEALTHCHECK
- `agentdx_bridge/requirements.txt` — agentdx, langfuse<3, prometheus_client

## Test results: 275/275 passed

```
275 passed in 0.39s
```

Stage 4 tests (50): converter tested with 6 fixture shapes — tool use, error tools, string output, out-of-order timestamps, empty observations, mixed content. All converter logic verified without requiring agentdx/langfuse at test time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)